### PR TITLE
Fix tag deletion and tweet retrieval

### DIFF
--- a/frontend/get_articles.py
+++ b/frontend/get_articles.py
@@ -1,6 +1,6 @@
 from django.shortcuts import reverse,redirect
 from .utils import *
-from api.models import Tag
+from api.models import Article, Tag
 from django.conf import settings
 from django.http import JsonResponse
 from django.contrib.auth.decorators import login_required
@@ -52,3 +52,16 @@ def remove_tag(request,pk):
     except Tag.DoesNotExist:
         pass
     return JsonResponse({"success":"Success"})
+
+def get_tweets(request, pk):
+    """Return tweets for a given article."""
+    try:
+        obj = Article.objects.get(pk=pk)
+        if obj.twitter_data.get("tweets") is None:
+            tweets = twitter_from_doi(obj.title, obj.identifiers.get("doi"))
+            obj.twitter_data = {"tweets": tweets}
+            obj.save()
+            return JsonResponse({"tweets": tweets})
+        return JsonResponse({"tweets": obj.twitter_data.get("tweets")})
+    except Exception as e:
+        return JsonResponse({"error": str(e)}, status=500)

--- a/frontend/urls.py
+++ b/frontend/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
 
     path('add_tag/<pk>/',get_articles.add_tag,name='add_tag'),
     path('remove_tag/<pk>/',get_articles.remove_tag,name='remove_tag'),
+    path('get_tweets/<pk>/',get_articles.get_tweets,name='get_tweets'),
 
     path('lan/<str:lan>/',views.change_lan),
 

--- a/frontend/utils.py
+++ b/frontend/utils.py
@@ -6,6 +6,28 @@ from api.models import Article,Authors
 from django.db.models import ObjectDoesNotExist
 import json
 
+def twitter_from_doi(title, doi):
+    """Fetch tweets referencing a DOI or title."""
+    header = {'Authorization': f'Bearer {settings.TWITTER_BEARER}'}
+    res_doi = requests.post(
+        'https://api.twitter.com/1.1/tweets/search/fullarchive/prod.json',
+        headers=header,
+        json={'query': f'url: "{doi}"', 'fromDate': '201001010101', 'toDate': '202001010101'}
+    )
+    res_title = requests.post(
+        'https://api.twitter.com/1.1/tweets/search/fullarchive/prod.json',
+        headers=header,
+        json={'query': f'"{title}"', 'fromDate': '201001010101', 'toDate': '202001010101'}
+    )
+
+    if res_doi.ok and res_title.ok:
+        return [*res_doi.json()['results'], *res_title.json()['results']]
+    if res_doi.ok:
+        return res_doi.json()['results']
+    if res_title.ok:
+        return res_title.json()['results']
+    return []
+
 def get_abstract(doi):
     try:
         res = requests.get(f'https://api.altmetric.com/v1/doi/{doi}').json()


### PR DESCRIPTION
## Summary
- restore `twitter_from_doi` helper
- import `Article` model in tag views
- provide `/get_tweets/<pk>/` route
- fix `get_tweets` implementation

## Testing
- `pip3 install -r req.txt`
- `python3 manage.py test` *(fails: OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840cd822c00832790a92749ca913e15