### PR TITLE
Switch database configuration to MySQL

### DIFF
--- a/Instructions.txt
+++ b/Instructions.txt
@@ -5,6 +5,10 @@ For Linux/Mac:
               install the requirements stated in req.txt:
                 pip3 install -r req.txt
 
+              install MySQL and create a database named "paper":
+                https://dev.mysql.com/doc/
+              update database credentials in PaperMetrics/settings.py if needed
+
               also install redis:
                 https://redis.io/download
               After downloading redis, add it to path variable.
@@ -26,6 +30,8 @@ For windows:
               install the requirements stated in req.txt:
                 pip install -r req.txt
 
+              install MySQL and create a database named "paper" as described in MySQL docs.
+              
               also install redis:
                 https://github.com/microsoftarchive/redis/releases/tag/win-3.0.504
               After downloading redis, add it to path variable.

--- a/PaperMetrics/settings.py
+++ b/PaperMetrics/settings.py
@@ -95,13 +95,13 @@ AUTH_USER_MODEL = 'authorization.User'
 # }
 
 DATABASES = {
-    'default':{
-        'ENGINE':'django.db.backends.postgresql_psycopg2',
-        'HOST':'',
-        'PORT':'',
-        'NAME':'paper',
-        'USER':'postgres',
-        'PASSWORD':'vihas007'
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'HOST': 'localhost',
+        'PORT': '3306',
+        'NAME': 'paper',
+        'USER': 'root',
+        'PASSWORD': ''
     }
 }
 

--- a/req.txt
+++ b/req.txt
@@ -3,7 +3,7 @@ celery
 redis
 django-celery-beat==2.2.1
 django-crispy-forms
-psycopg2
+mysqlclient
 scikit-learn
 pandas
 requests>=2.32.0


### PR DESCRIPTION
## Summary
- use MySQL as the default database
- install `mysqlclient`
- document MySQL setup instructions

## Testing
- `python -m pip install -r req.txt`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6841027387588327bff7c831f620090e