### PR TITLE
Implement DeepSeek recommendations and remove Tweepy

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,9 +1,0 @@
-import tweepy
-
-auth = tweepy.OAuthHandler('c7nf0odpA7Xmoq8eREdZFx5e1', 'zzy3k40GWtyPsq5kv2HV9RSx4s8449mB9YIVdnVM5CeRmGx3PQ')
-auth.set_access_token('1337349594544369666-0LbUymtwlOeNwC4B9zVGfBgKJ7S8ws', '0TTb5uIZOvda6CEVt0XUM0wbovZ8GMm617cbn79QoIiuM')
-
-api = tweepy.API(auth)
-public_tweets = api.search_full_archive(environment_name='prod',query='"Proximal Algorithms"')
-for tweet in public_tweets:
-    print(tweet._json['id'])

--- a/api/admin.py
+++ b/api/admin.py
@@ -4,7 +4,7 @@ from .models import Article, Authors
 
 @admin.register(Article)
 class ArticleAdmin(admin.ModelAdmin):
-    list_display = ("title", "publisher", "year", "score")
+    list_display = ("title", "publisher", "year", "score", "upvotes", "downvotes", "final_score")
     search_fields = ("title", "publisher")
 
 

--- a/api/deepseek_client.py
+++ b/api/deepseek_client.py
@@ -1,19 +1,40 @@
-"""Client module for interacting with DeepSeek recommendation API."""
+"""Utilities for interacting with the DeepSeek recommendation service."""
+
 from __future__ import annotations
 
+import logging
 import os
 from typing import List
 
 import requests
 
-API_URL = "https://api.deepseek.com/search"  # hypothetical endpoint
+
+API_URL = "https://api.deepseek.com/search"  # Hypothetical endpoint.
+
+logger = logging.getLogger(__name__)
 
 
 def recommend_articles(prompt: str, limit: int = 5) -> List[str]:
-    """Query DeepSeek for article recommendations."""
+    """Return a list of article IDs recommended by DeepSeek.
+
+    Parameters
+    ----------
+    prompt:
+        Text used for the search prompt.
+    limit:
+        Maximum number of results to return.
+
+    Returns
+    -------
+    List[str]
+        A list of article identifiers sorted by relevance.  An empty list is
+        returned if the request fails or no results were found.
+    """
+
     api_key = os.environ.get("DEEPSEEK_API_KEY")
     if not api_key:
-        raise RuntimeError("DEEPSEEK_API_KEY not configured")
+        logger.warning("DEEPSEEK_API_KEY not configured")
+        return []
 
     try:
         response = requests.post(
@@ -25,5 +46,7 @@ def recommend_articles(prompt: str, limit: int = 5) -> List[str]:
         response.raise_for_status()
         data = response.json()
         return data.get("ids", [])
-    except Exception:
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("DeepSeek request failed: %s", exc)
         return []
+

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -330,7 +330,8 @@ class DetailArticle(DetailView):
     model = Article
     template_name = "frontend/detail.html"
     def get(self,request,pk):
-        super(DetailArticle,self).get(request,pk)
+        """Render detail view for an article with smart recommendations."""
+        super().get(request,pk)
         self.object = self.get_object()
         context = self.get_context_data()
         from api.models import Vote
@@ -343,8 +344,9 @@ class DetailArticle(DetailView):
         except TypeError:
             pass
 
-        # Prefer recommendations from the DeepSeek API when available. Failures
-        # result in falling back to the TF-IDF based approach.
+        # Prefer recommendations from the DeepSeek API when available. If the
+        # API returns nothing or fails we fall back to the TF‑IDF based
+        # keyword recommender.
         context['ids'] = []
         prompt = f"{self.object.title} {self.object.abstract} {' '.join(self.object.keywords or [])}"
         rec_ids = recommend_articles(prompt, limit=20)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pandas
 requests>=2.32.0
 mendeley
 python-dotenv
+psycopg2-binary

--- a/templates/frontend/index.html
+++ b/templates/frontend/index.html
@@ -1,20 +1,10 @@
+{% extends 'base.html' %}
 {% load static %}
 {% load i18n %}
 
-<html>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-
-  <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="{% static "dist/tailwind.css" %}">
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
-  <script src="https://pagination.js.org/dist/2.1.5/pagination.js"></script>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css" integrity="sha512-HK5fgLBL+xu6dm/Ii3z4xhlSUyZgTT9tuc/hSrtw6uzJOvgRr2a9jyxxT1ely+B+xFAmJKVSTbpM/CuL7qxO8w==" crossorigin="anonymous" />
-  <link rel="stylesheet" href="https://pagination.js.org/dist/2.1.5/pagination.css">
-  <style media="screen">
+{% block content %}
+<script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+<style media="screen">
     #card_div{
       width:100%;
     }
@@ -71,9 +61,7 @@
     }
 
   </style>
-</head>
-
-<body>
+</style>
 {% include 'nav.html' %}
   <div class="container mt-4">
     <h3 class="mb-3">Top Trending Papers</h3>
@@ -213,7 +201,6 @@
     </div>
   </div>
 
-</body>
 <!-- <script src="{% static "js/main.js" %}"></script> -->
 <script type="text/javascript">
     function clickedUpvote(ele,id) {
@@ -305,7 +292,7 @@
         return dat;
     }
     $(document).ready(()=>{
-      $.get("{% url 'get_article_top' %}", (res)=>{
+      $.get("{% url 'get_article_trending' %}", (res)=>{
         let html='';
         $.each(res.slice(0,6), function(_,item){
           html+=`<div class="col"><div class="card glass p-2"><a href='/article/${item.id}'>${item.title}</a><div class='small text-muted'>Votes: ${item.vote}</div></div></div>`;
@@ -509,4 +496,4 @@ position: relative;
 }
   </style>
 </div>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- remove unused Tweepy helper
- expose more info in Article admin
- add DeepSeek client with logging
- integrate DeepSeek recommendations in article view
- refresh homepage layout and use trending data
- add psycopg2-binary to requirements

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: Can't connect to local MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_684179af9368832783db519b97675f04