### PR TITLE
Fix list_documents view

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -1,3 +1,27 @@
 from django.test import TestCase
+from django.urls import reverse
+from unittest.mock import patch, Mock
 
-# Create your tests here.
+
+class DocumentListTests(TestCase):
+    """Tests for the list_documents view."""
+
+    @patch("api.views.requests.get")
+    def test_list_documents_with_token(self, mock_get):
+        """View should render when a token is present in the session."""
+        profile_resp = Mock(ok=True)
+        profile_resp.json.return_value = {"display_name": "Tester"}
+        docs_resp = Mock(ok=True)
+        docs_resp.json.return_value = [{"id": "d1", "title": "Doc"}]
+        mock_get.side_effect = [profile_resp, docs_resp]
+
+        session = self.client.session
+        session["token"] = {"access_token": "abc"}
+        session.save()
+
+        res = self.client.get(reverse("list_documents"))
+
+        self.assertEqual(res.status_code, 200)
+        self.assertTemplateUsed(res, "api/library.html")
+        self.assertContains(res, "Tester")
+        self.assertContains(res, "Doc")

--- a/api/views.py
+++ b/api/views.py
@@ -31,12 +31,21 @@ def list_documents(request):
     if 'token' not in request.session:
         return redirect('/')
 
-    # print(dict(request.session))
-    # utils.get_data(request.session["token"]['access_token'])
-    #
-    headers = {"Authorization": "Bearer "+request.session["token"]['access_token']}
+    headers = {"Authorization": "Bearer " + request.session['token']['access_token']}
 
-    return render(request,'api/library.html', {"name":name, "docs":docs})
+    # Fetch the user profile to display the library owner's name.
+    profile_res = requests.get("https://api.mendeley.com/profiles/me", headers=headers)
+    if profile_res.ok:
+        profile = profile_res.json()
+        name = profile.get("display_name") or f"{profile.get('first_name', '')} {profile.get('last_name', '')}".strip()
+    else:
+        name = ""
+
+    # Retrieve the list of documents in the user's library.
+    docs_res = requests.get("https://api.mendeley.com/documents", headers=headers)
+    docs = docs_res.json() if docs_res.ok else []
+
+    return render(request, 'api/library.html', {"name": name, "docs": docs})
 
 
 def get_document(request):


### PR DESCRIPTION
## Summary
- implement Mendeley API calls in `list_documents`
- add regression test for document list view

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_684194a1bd7c832795f628f5537e0ff3